### PR TITLE
Fix region selection for S3 service

### DIFF
--- a/coupon_core/utils/s3.py
+++ b/coupon_core/utils/s3.py
@@ -41,7 +41,9 @@ class S3Service:
         self.endpoint_url = endpoint_url or getattr(settings, "AWS_S3_ENDPOINT_URL", None)
         self.bucket_name = bucket_name or getattr(settings, "AWS_STORAGE_BUCKET_NAME")
         self.region_name = (
-            _infer_region_from_endpoint(self.endpoint_url)
+            region_name
+            or getattr(settings, "AWS_S3_REGION_NAME", None)
+            or _infer_region_from_endpoint(self.endpoint_url)
         )
         self.client = boto3.client(
             "s3",


### PR DESCRIPTION
## Summary
- handle `region_name` parameter in `S3Service`
- fall back to `AWS_S3_REGION_NAME` from settings or inferred region

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68444f18dbfc833195ab9c1571993341