### PR TITLE
Improve search fuzzy matching

### DIFF
--- a/discountcrawlers/discountcrawlers/services/search_service.py
+++ b/discountcrawlers/discountcrawlers/services/search_service.py
@@ -4,9 +4,8 @@ This module provides a SearchService class for searching and filtering discount 
 using Redis as a backend.
 """
 
-from typing import List, Optional, Dict, Any
-from datetime import datetime
-import json
+from typing import List, Optional
+from rapidfuzz import fuzz
 
 from discountcrawlers.utils.redis_utils import RedisUtils
 from discountcrawlers.services.storage_service import StorageService
@@ -60,12 +59,17 @@ class SearchService:
         # Get all items from storage
         all_items = await self.storage_service.list_items()
         
-        # Filter items
+        # Filter items using fuzzy matching for more robust queries
         filtered_items = []
         for item in all_items:
-            if query.lower() not in item["title"].lower():
-                continue
-                
+            title = item["title"].lower()
+            # Basic substring match for quick wins
+            if query:
+                q_lower = query.lower()
+                similarity = fuzz.token_set_ratio(q_lower, title)
+                if q_lower not in title and similarity < 60:
+                    continue
+
             if store and item["store_name"] != store:
                 continue
                 

--- a/discountcrawlers/tests/integration/services/test_search_service_integration.py
+++ b/discountcrawlers/tests/integration/services/test_search_service_integration.py
@@ -195,4 +195,15 @@ async def test_search_cache(search_service, storage_service, sample_items):
     assert all(
         first["url"] == second["url"]
         for first, second in zip(first_results, second_results)
-    ) 
+    )
+
+
+@pytest.mark.asyncio
+async def test_fuzzy_search(search_service, storage_service, sample_items):
+    """Search should handle typos and partial matches."""
+    for item in sample_items:
+        await storage_service.store_item(item)
+
+    results = await search_service.search("Tst Itm")
+    assert len(results) > 0
+    assert any("Test Item" in item["title"] for item in results)


### PR DESCRIPTION
## Summary
- add rapidfuzz to allow fuzzy search
- update SearchService to use fuzzy matching for vague queries
- test fuzzy matching with typos

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6844534158d88331a7333dc8d00cc163