### PR TITLE
Add Helm setup step to CI workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -123,6 +123,9 @@ jobs:
           pattern: version-metadata.json
           merge-multiple: false
 
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+
       - name: Configure kubectl for DigitalOcean
         run: |
           mkdir -p ~/.kube

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,6 +73,9 @@ jobs:
       - name: Verify kubeconfig access
         run: kubectl get nodes
 
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+
       - name: Validate Namespace
         run: |
           if [ -z "$NAMESPACE" ]; then


### PR DESCRIPTION
## Summary
- install Helm in `ci.yaml` workflow
- install Helm in `deploy.yml` workflow

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684567f9a5108331b7bb5fe566f05801